### PR TITLE
Move JSON::PP::Boolean to dist

### DIFF
--- a/lib/JSON/PP/Boolean.pm
+++ b/lib/JSON/PP/Boolean.pm
@@ -1,0 +1,35 @@
+package JSON::PP::Boolean;
+
+use strict;
+use overload (
+    "0+"     => sub { ${$_[0]} },
+    "++"     => sub { $_[0] = ${$_[0]} + 1 },
+    "--"     => sub { $_[0] = ${$_[0]} - 1 },
+    fallback => 1,
+);
+
+$JSON::PP::Boolean::VERSION = '2.97001';
+
+1;
+
+__END__
+
+=head1 NAME
+
+JSON::PP::Boolean - dummy module providing JSON::PP::Boolean
+
+=head1 SYNOPSIS
+
+ # do not "use" yourself
+
+=head1 DESCRIPTION
+
+This module exists only to provide overload resolution for Storable and similar modules. See
+L<JSON::PP> for more info about this class.
+
+=head1 AUTHOR
+
+This idea is from L<JSON::XS::Boolean> written by Marc Lehmann <schmorp[at]schmorp.de>
+
+=cut
+

--- a/lib/JSON/PP/Boolean.pm
+++ b/lib/JSON/PP/Boolean.pm
@@ -1,18 +1,14 @@
+
+use Types::Bool ();
+
 package JSON::PP::Boolean;
 
-use strict;
-use overload (
-    "0+"     => sub { ${$_[0]} },
-    "++"     => sub { $_[0] = ${$_[0]} + 1 },
-    "--"     => sub { $_[0] = ${$_[0]} - 1 },
-    fallback => 1,
-);
-
-$JSON::PP::Boolean::VERSION = '2.97001';
+$JSON::PP::Boolean::VERSION = '2.98004'
+  unless $JSON::PP::Boolean::VERSION;
 
 1;
 
-__END__
+=encoding utf8
 
 =head1 NAME
 
@@ -25,11 +21,11 @@ JSON::PP::Boolean - dummy module providing JSON::PP::Boolean
 =head1 DESCRIPTION
 
 This module exists only to provide overload resolution for Storable and similar modules. See
-L<JSON::PP> for more info about this class.
+L<Types::Bool> for more info about this class.
 
 =head1 AUTHOR
 
-This idea is from L<JSON::XS::Boolean> written by Marc Lehmann <schmorp[at]schmorp.de>
+This idea is from L<JSON::XS::Boolean> written by Marc Lehmann.
 
 =cut
 


### PR DESCRIPTION
This can only be done if the maintainer has permissions on `JSON::PP::Boolean` module.